### PR TITLE
Perspective transform improvements

### DIFF
--- a/TODO
+++ b/TODO
@@ -19,18 +19,23 @@ TODO:
 
 7/27/2024:
 In progress:
-- fix perspective shift with glfx
-  - there's a slight offset on the transformed video?
-  - I'm pretty sure the transform itself is right, but maybe retest it
-    - yeah retested and it still looks fine, so probably not problem with that
-  - and I think maybe can try out just inputting the user and reference pose stores into the perspective directly
-  - then we wouldn't even have to calculate the transform
 - uh fuck and also debugging the first frame drawing on the normal canvas??
   - not working for user pose
 - support instagram embed links
 - test on ipad
 
 Done:
+- fix perspective shift with glfx
+  - yeah so just relying on the perspective transform from glfx instead of doing it ourselves lmao
+  - there's a slight offset on the transformed video?
+  - and also just like figuring out the dimensions of the frame canvas in glfx
+    - mm yeah doing this actually not great, since it actually seems to affect the resolution of the output!
+    - so maybe trying out now just using the user and reference poses directly
+  - and I think maybe can try out just inputting the user and reference pose stores into the perspective directly
+    - poggg this works really well actually
+  - then we wouldn't even have to calculate the transform! yes!
+  - I'm pretty sure the transform itself is right, but maybe retest it
+    - yeah retested and it still looks fine, so probably not problem with that
 - improve perspective transform performance:
   - smooth out glfx bugs
   - updated the pose updates logic to be cleaner and just redraw the landmarks themselves (instead of the whole frame)

--- a/TODO
+++ b/TODO
@@ -19,12 +19,18 @@ TODO:
 
 7/27/2024:
 In progress:
-- uh fuck and also debugging the first frame drawing on the normal canvas??
-  - not working for user pose
 - support instagram embed links
 - test on ipad
 
 Done:
+- uh fuck and also debugging the first frame drawing on the normal canvas??
+  - what's working for me is just seeking to currenttime = 0 lmao which triggers the onSeek frame draw. nice!
+  - not working for user pose
+  - uhh so I guess maybe looking at the video ref and why it's not showing up?
+  - uh ok so when stepping, it seems the video is drawn on the frame...
+  - but maybe sometimes the video ref is still null?
+  - yeah idk wtf the actual cause is lol
+    - but seems other people have similar issue
 - fix perspective shift with glfx
   - yeah so just relying on the perspective transform from glfx instead of doing it ourselves lmao
   - there's a slight offset on the transformed video?

--- a/TODO
+++ b/TODO
@@ -19,6 +19,14 @@ TODO:
 
 7/27/2024:
 In progress:
+- fix perspective shift with glfx
+  - there's a slight offset on the transformed video?
+  - I'm pretty sure the transform itself is right, but maybe retest it
+    - yeah retested and it still looks fine, so probably not problem with that
+  - and I think maybe can try out just inputting the user and reference pose stores into the perspective directly
+  - then we wouldn't even have to calculate the transform
+- uh fuck and also debugging the first frame drawing on the normal canvas??
+  - not working for user pose
 - support instagram embed links
 - test on ipad
 

--- a/TODO
+++ b/TODO
@@ -17,6 +17,15 @@ TODO:
   - improve code quality
 
 
+7/26/2024:
+In progress:
+- improve perspective transform performance:
+  - smooth out glfx bugs
+- support instagram embed links
+- test on ipad
+
+
+
 7/18/2024:
 In progress:
 - improve perspective transform performance

--- a/TODO
+++ b/TODO
@@ -17,12 +17,17 @@ TODO:
   - improve code quality
 
 
-7/26/2024:
+7/27/2024:
 In progress:
-- improve perspective transform performance:
-  - smooth out glfx bugs
 - support instagram embed links
 - test on ipad
+
+Done:
+- improve perspective transform performance:
+  - smooth out glfx bugs
+  - updated the pose updates logic to be cleaner and just redraw the landmarks themselves (instead of the whole frame)
+  - separating frame and display canvases for user frame as well!
+    - yeah so drawing video frame to frame-canvas in user video
 
 
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -139,23 +139,17 @@ export function applyTransformToPose(pose: NormalizedLandmark[], transform: Pers
   });
 }
 
-function perspectivesEqual(p1: Perspective, p2: Perspective) {
-  const [[a1x, a1y], [b1x, b1y], [c1x, c1y], [d1x, d1y]] = p1;
-  const [[a2x, a2y], [b2x, b2y], [c2x, c2y], [d2x, d2y]] = p2;
-  return (
-    a1x === a2x &&
-    a1y === a2y &&
-    b1x === b2x &&
-    b1y === b2y &&
-    c1x === c2x &&
-    c1y === c2y &&
-    d1x === d2x &&
-    d1y === d2y
-  );
+function approxEq(a: number, b: number) {
+  return Math.abs(a - b) < 0.001;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function test() {
+function perspectivesEqual(p1: Perspective, p2: Perspective) {
+  const a = p1.flat();
+  const b = p2.flat();
+  return a.every((v, i) => approxEq(v, b[i]));
+}
+
+function testSameSourceAndDest(): boolean {
   const source_coords = [
     [0.1, 0.1],
     [0.9, 0.1],
@@ -175,10 +169,44 @@ function test() {
     [0.0, 1.0]
   ] as Perspective;
   const same_coords_actual_output = calculateTransform(source_coords, dest_coords);
-  console.log(same_coords_actual_output, same_coords_expected_output);
-  console.log(
-    perspectivesEqual(same_coords_actual_output, same_coords_expected_output)
-      ? 'success'
-      : 'failure'
-  );
+  console.log('Same coords test:');
+  console.log('Expected:');
+  console.table(same_coords_expected_output);
+  console.log('Actual:');
+  console.table(same_coords_actual_output);
+  return perspectivesEqual(same_coords_actual_output, same_coords_expected_output);
+}
+
+function testSimpleScaling(): boolean {
+  const source_coords = [
+    [0.1, 0.1],
+    [0.9, 0.1],
+    [0.9, 0.9],
+    [0.1, 0.9]
+  ] as Perspective;
+  const dest_coords = [
+    [0.3, 0.3],
+    [0.7, 0.3],
+    [0.7, 0.7],
+    [0.3, 0.7]
+  ] as Perspective;
+  const expected_output = [
+    [0.25, 0.25],
+    [0.75, 0.25],
+    [0.75, 0.75],
+    [0.25, 0.75]
+  ] as Perspective;
+  const actual_output = calculateTransform(source_coords, dest_coords);
+  console.log('Simple scaling test:');
+  console.log('Expected:');
+  console.table(expected_output);
+  console.log('Actual:');
+  console.table(actual_output);
+  return perspectivesEqual(actual_output, expected_output);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function test() {
+  console.log(testSameSourceAndDest() ? 'success' : 'failure');
+  console.log(testSimpleScaling() ? 'success' : 'failure');
 }

--- a/src/routes/VideoScrubber.svelte
+++ b/src/routes/VideoScrubber.svelte
@@ -73,10 +73,7 @@
     frameCanvasRef.height = canvasHeight;
 
     // Draw the first frame of the video
-    const context = displayCanvasRef.getContext('2d');
-    if (!context) return;
-
-    drawFrame(context, canvasWidth, canvasHeight);
+    videoRef.currentTime = 0;
   });
 
   $: {

--- a/src/routes/VideoScrubber.svelte
+++ b/src/routes/VideoScrubber.svelte
@@ -213,13 +213,19 @@
     const context = displayCanvasRef.getContext('2d');
     if (!context) return;
 
-    const frameWidth = videoRef.offsetWidth;
-    const frameHeight = videoRef.offsetHeight;
-    context.clearRect(0, 0, frameWidth, frameHeight);
+    if (isReference) {
+      // For the reference video, just redraw the pose overlay
+      const frameWidth = videoRef.offsetWidth;
+      const frameHeight = videoRef.offsetHeight;
+      context.clearRect(0, 0, frameWidth, frameHeight);
 
-    const drawingUtils = new DrawingUtils(context);
-    drawLandmark(drawingUtils, $userPose, $userPoseColor);
-    drawLandmark(drawingUtils, $referencePose, $referencePoseColor);
+      const drawingUtils = new DrawingUtils(context);
+      drawLandmark(drawingUtils, $userPose, $userPoseColor);
+      drawLandmark(drawingUtils, $referencePose, $referencePoseColor);
+    } else {
+      // For the user video, redraw the whole frame
+      drawFrameAsUser(context, videoRef.offsetWidth, videoRef.offsetHeight, false);
+    }
   };
 
   const onInput = () => {

--- a/src/routes/VideoScrubber.svelte
+++ b/src/routes/VideoScrubber.svelte
@@ -70,34 +70,12 @@
 
   $: {
     if (
-      isReference &&
-      $userPose &&
-      !isPlaying &&
-      displayCanvasRef &&
-      videoRef &&
-      detectionCanvasRef
+      // If this is the reference video, the video isn't playing, and the user pose is updated, redraw the landmarks
+      (isReference && $userPose && !isPlaying && displayCanvasRef) ||
+      // If this is the user video, the video isn't playing, and the reference pose is updated, redraw the landmarks
+      (!isReference && $referencePose && !isPlaying && displayCanvasRef)
     ) {
-      // TODO: draw perspective shifted frame
-      const context = displayCanvasRef.getContext('2d');
-      if (context) {
-        drawFrameAsReference(context, videoRef.offsetWidth, videoRef.offsetHeight, false);
-      }
-    }
-  }
-
-  $: {
-    if (
-      !isReference &&
-      $referencePose &&
-      !isPlaying &&
-      displayCanvasRef &&
-      videoRef &&
-      detectionCanvasRef
-    ) {
-      const context = displayCanvasRef.getContext('2d');
-      if (context) {
-        drawFrameAsUser(context, videoRef.offsetWidth, videoRef.offsetHeight, false);
-      }
+      redrawLandmarks();
     }
   }
 
@@ -229,6 +207,19 @@
       lineWidth: 2,
       color
     });
+  };
+
+  const redrawLandmarks = () => {
+    const context = displayCanvasRef.getContext('2d');
+    if (!context) return;
+
+    const frameWidth = videoRef.offsetWidth;
+    const frameHeight = videoRef.offsetHeight;
+    context.clearRect(0, 0, frameWidth, frameHeight);
+
+    const drawingUtils = new DrawingUtils(context);
+    drawLandmark(drawingUtils, $userPose, $userPoseColor);
+    drawLandmark(drawingUtils, $referencePose, $referencePoseColor);
   };
 
   const onInput = () => {


### PR DESCRIPTION
### Perspective transform improvements
Previous implementation of perspective transform involved manually calculating the transform of the reference video, and using the `perspective.ts` library which was very slow (drawing slices of the canvas), allowing rendering of only 10 fps. In this PR, we switch to `glfx` (I'm an even bigger Evan Wallace glazer now), which both renders the perspective transform faster (via WebGL canvas context) and also can just directly handle the actual perspective shift calculations.
* Switching to `glfx`
* Removing usages of `perspective.ts` and associated `lib` functions

### Pose syncing improvements
As part of adding `glfx`, I've also split up the frame and pose display canvases. One canvas holds just the current frame of the video we're displaying (with possible perspective transform controlled by `glfx`), while another canvas holds just the detected user and reference landmarks. This helps us sync landmarks between the two video components, since we now only have to redraw the pose canvas which is much faster and simplifies implementation considerably.
* Separating frame and pose display canvases
* Simplifying reactive code blocks for redrawing landmarks on pose changes

### Other QOL changes
* Now properly drawing the first frame of the video when the `VideoScrubber` component mounts (by seeking to the start of the video, triggering the `onSeek` frame render)
* Updating perspective transform calculation tests (although we aren't using these functions for now)