### PR TITLE
iOS Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ npm run dev
 # or start the server and open the app in a new browser tab
 npm run dev -- --open
 
-# use the host flag to allow other devices on your local network to connect to the dev server
+# use the `host` flag to allow other devices on your local network to connect to the dev server
 # useful for testing on mobile devices
 npm run dev:host
 ```

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ npm run dev
 
 # or start the server and open the app in a new browser tab
 npm run dev -- --open
+
+# use the host flag to allow other devices on your local network to connect to the dev server
+# useful for testing on mobile devices
+npm run dev:host
 ```
 
 ## Building

--- a/TODO
+++ b/TODO
@@ -27,10 +27,16 @@ TODO:
     - PR: https://github.com/alanzhu39/alpha-beta/pull/1
 
 
+9/3/2024:
+In progress:
+- ios bugfixes
+  - fix video stuttering on ios (this happens on my phone too)
+
+
+
 9/1/2024:
 In progress:
 - ios bugfixes
-  - add video playsinline so that videos don't full screen by default
 - design updates
   - move menu into hamburger in right corner
     - could also have settings here
@@ -41,6 +47,10 @@ In progress:
   - update slider appearances (and behavior?)
     - how do we make sliding behavior in webapps smoother on ipad?
   - update boundary selection
+
+Done:
+- ios bugfixes
+  - add video playsinline so that videos don't full screen by default
 
 ios debug notes:
 - ok some bug causes notes:

--- a/TODO
+++ b/TODO
@@ -27,6 +27,21 @@ TODO:
     - PR: https://github.com/alanzhu39/alpha-beta/pull/1
 
 
+9/1/2024:
+In progress:
+- ios bugfixes
+  - add video playsinline so that videos don't full screen by default
+- design updates
+  - move menu into hamburger in right corner
+  - orr, move alphabeta title into the footer?
+  - add padding at bottom of the page, so that the video sliders are not overlapping the ipad gesture controls
+  - add prettier backgrounds (maybe dark mode?)
+  - update slider appearances (and behavior?)
+    - how do we make sliding behavior in webapps smoother on ipad?
+  - update boundary selection
+
+
+
 8/25/2024:
 In progress:
 - fix video display on iOS

--- a/TODO
+++ b/TODO
@@ -33,12 +33,59 @@ In progress:
   - add video playsinline so that videos don't full screen by default
 - design updates
   - move menu into hamburger in right corner
+    - could also have settings here
+    - or popup modal instead of hamburger
   - orr, move alphabeta title into the footer?
   - add padding at bottom of the page, so that the video sliders are not overlapping the ipad gesture controls
   - add prettier backgrounds (maybe dark mode?)
   - update slider appearances (and behavior?)
     - how do we make sliding behavior in webapps smoother on ipad?
   - update boundary selection
+
+ios debug notes:
+- ok some bug causes notes:
+- occurs when we try to draw onplay with glfx
+- works when we draw a single frame...
+- single frame works with both perspective and no perspective
+- so it's an issue only when playing the video
+- it seems like the video kinda disappears?
+- or like, when it's playing, it can't pull frames from the video
+- but it works without glfx, so just drawing to the canvas straight from the video as normal
+  - eg. when we do the user frame drawing
+- ok so I did some testing, it seems that we are indeed losing the glfx webgl rendering context when playing the video!
+  - figured this out by adding an event listener for the webglcontext lost event, and it got fired on video play
+  - not sure why this happens, there are a variety of reasons
+  - I'm wondering if maybe it's like too much load on the gpu so safari booms it
+  - and same issue of context loss on chrome
+- oooook so I think it's something with like the system just having a ton of memory leaks and pooping out because of that?
+- so like when I don't constantly refresh the texture, it works fine.
+- is there a way to make the video texture binding much more efficient?
+- hmm ok, so, I've changed the glfx rendering to update the texture, instead of re-creating it each time
+- I think that's helped resolve much of the memory leak, where we were re-creating the texture each time and not deleting it
+  which was hella slow
+  - also maybe wanna test out deleting as well?
+  - mm nah but it seems like current way is (probably) for sure the best
+- buuut, I've been running into issues where we still lose the webgl context because I think the pose compute,
+  which we had running on the GPU, was also eating up a lot of bandwidth
+- so I think we have to just run the pose detection on CPU for now?
+- should probably expose these in some settings menu:
+  - pose detection: CPU or GPU (maybe auto-detect depending on your machine?)
+  - pose model selection: heavy, full, lite
+  - maybe even want to add fallback for the perspective transform? so using the perspective.ts version
+    if GPU is not supported
+- new problem: for some reason, something new broke.
+  - so basically, when we draw the reference pose (with webgl initialized),
+    even if we're fricking not even doing any drawing with glfx, the underlying video is stuttering
+  - could this be because of like CPU/GPU load which causes decoding to be slower?
+  - cuz like, the JS that's running actually seems to be going at like 30 fps,
+    it just reads the frames from the stuttered video, which then causes the canvas display to stall as well
+  - yeahhh, like you can see the pose itself actually shifting around a tiny bit on each frame even when it's frozen,
+    which is more evidence for the video itself being laggy, since it's detecting the pose still on the fly on each frame,
+    just the actual underlying frame is frozen because the *video* itelf is actually frozen
+  - how to fix???
+
+notes:
+- javascripts has special `arguments` object that basically holds the arguments coming into the function call
 
 
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "vite dev",
+    "dev:host": "vite dev --host",
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -17,6 +17,7 @@ declare module 'glfx-es6' {
     constructor();
     width: number;
     height: number;
+    loadContentsOf(element: HTMLVideoElement): void;
   }
 
   interface GlfxCanvas extends HTMLCanvasElement {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,17 @@
+/* eslint-disable */
+// @ts-nocheck
+export function mobileCheck(): boolean {
+  let check = false;
+  (function (a) {
+    if (
+      /(android|bb\d+|meego).+mobile|avantgo|bada\/|blackberry|blazer|compal|elaine|fennec|hiptop|iemobile|ip(hone|od)|iris|kindle|lge |maemo|midp|mmp|mobile.+firefox|netfront|opera m(ob|in)i|palm( os)?|phone|p(ixi|re)\/|plucker|pocket|psp|series(4|6)0|symbian|treo|up\.(browser|link)|vodafone|wap|windows ce|xda|xiino|android|ipad|playbook|silk/i.test(
+        a
+      ) ||
+      /1207|6310|6590|3gso|4thp|50[1-6]i|770s|802s|a wa|abac|ac(er|oo|s\-)|ai(ko|rn)|al(av|ca|co)|amoi|an(ex|ny|yw)|aptu|ar(ch|go)|as(te|us)|attw|au(di|\-m|r |s )|avan|be(ck|ll|nq)|bi(lb|rd)|bl(ac|az)|br(e|v)w|bumb|bw\-(n|u)|c55\/|capi|ccwa|cdm\-|cell|chtm|cldc|cmd\-|co(mp|nd)|craw|da(it|ll|ng)|dbte|dc\-s|devi|dica|dmob|do(c|p)o|ds(12|\-d)|el(49|ai)|em(l2|ul)|er(ic|k0)|esl8|ez([4-7]0|os|wa|ze)|fetc|fly(\-|_)|g1 u|g560|gene|gf\-5|g\-mo|go(\.w|od)|gr(ad|un)|haie|hcit|hd\-(m|p|t)|hei\-|hi(pt|ta)|hp( i|ip)|hs\-c|ht(c(\-| |_|a|g|p|s|t)|tp)|hu(aw|tc)|i\-(20|go|ma)|i230|iac( |\-|\/)|ibro|idea|ig01|ikom|im1k|inno|ipaq|iris|ja(t|v)a|jbro|jemu|jigs|kddi|keji|kgt( |\/)|klon|kpt |kwc\-|kyo(c|k)|le(no|xi)|lg( g|\/(k|l|u)|50|54|\-[a-w])|libw|lynx|m1\-w|m3ga|m50\/|ma(te|ui|xo)|mc(01|21|ca)|m\-cr|me(rc|ri)|mi(o8|oa|ts)|mmef|mo(01|02|bi|de|do|t(\-| |o|v)|zz)|mt(50|p1|v )|mwbp|mywa|n10[0-2]|n20[2-3]|n30(0|2)|n50(0|2|5)|n7(0(0|1)|10)|ne((c|m)\-|on|tf|wf|wg|wt)|nok(6|i)|nzph|o2im|op(ti|wv)|oran|owg1|p800|pan(a|d|t)|pdxg|pg(13|\-([1-8]|c))|phil|pire|pl(ay|uc)|pn\-2|po(ck|rt|se)|prox|psio|pt\-g|qa\-a|qc(07|12|21|32|60|\-[2-7]|i\-)|qtek|r380|r600|raks|rim9|ro(ve|zo)|s55\/|sa(ge|ma|mm|ms|ny|va)|sc(01|h\-|oo|p\-)|sdk\/|se(c(\-|0|1)|47|mc|nd|ri)|sgh\-|shar|sie(\-|m)|sk\-0|sl(45|id)|sm(al|ar|b3|it|t5)|so(ft|ny)|sp(01|h\-|v\-|v )|sy(01|mb)|t2(18|50)|t6(00|10|18)|ta(gt|lk)|tcl\-|tdg\-|tel(i|m)|tim\-|t\-mo|to(pl|sh)|ts(70|m\-|m3|m5)|tx\-9|up(\.b|g1|si)|utst|v400|v750|veri|vi(rg|te)|vk(40|5[0-3]|\-v)|vm40|voda|vulc|vx(52|53|60|61|70|80|81|83|85|98)|w3c(\-| )|webc|whit|wi(g |nc|nw)|wmlb|wonu|x700|yas\-|your|zeto|zte\-/i.test(
+        a.substr(0, 4)
+      )
+    )
+      check = true;
+  })(navigator.userAgent || navigator.vendor || window.opera);
+  return check;
+}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -18,8 +18,8 @@
   }
 
   .layout {
-    width: 100vw;
-    height: 100vh;
+    width: 100dvw;
+    height: 100dvh;
     display: grid;
     grid-template:
       'header header' auto

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,13 @@
 <script>
+  import { onMount } from 'svelte';
   import ReferenceBetaFlow from './ReferenceBetaFlow.svelte';
   import UserBetaFlow from './UserBetaFlow.svelte';
+  import { isMobile } from './stores';
+  import { mobileCheck } from '../lib/utils';
+
+  onMount(() => {
+    $isMobile = mobileCheck();
+  });
 </script>
 
 <div class="layout">

--- a/src/routes/SelectBoundary.svelte
+++ b/src/routes/SelectBoundary.svelte
@@ -76,7 +76,14 @@
 <div class="container">
   <!-- TODO: back button -->
   <div class="video-container">
-    <video class="user-video" muted bind:this={videoRef} bind:duration={videoDuration}>
+    <video
+      class="user-video"
+      muted
+      playsinline
+      crossOrigin="anonymous"
+      bind:this={videoRef}
+      bind:duration={videoDuration}
+    >
       <source src={videoSrc} type="video/mp4" />
     </video>
     <canvas class="video-canvas" id="video-canvas" bind:this={canvasRef} on:click={onCanvasClick} />

--- a/src/routes/UserBetaFlow.svelte
+++ b/src/routes/UserBetaFlow.svelte
@@ -38,7 +38,7 @@
     <SelectBoundary {videoSrc} bind:corners nextStep={onSelectedBoundary} />
   {/if}
   {#if currentStep === STEPS.DISPLAY}
-    <VideoScrubber {videoSrc} backStep={onScrubberBack} />
+    <VideoScrubber {videoSrc} backStep={onScrubberBack} isReference={true} />
   {/if}
 </div>
 

--- a/src/routes/UserBetaFlow.svelte
+++ b/src/routes/UserBetaFlow.svelte
@@ -38,7 +38,7 @@
     <SelectBoundary {videoSrc} bind:corners nextStep={onSelectedBoundary} />
   {/if}
   {#if currentStep === STEPS.DISPLAY}
-    <VideoScrubber {videoSrc} backStep={onScrubberBack} isReference={true} />
+    <VideoScrubber {videoSrc} backStep={onScrubberBack} />
   {/if}
 </div>
 

--- a/src/routes/VideoScrubber.svelte
+++ b/src/routes/VideoScrubber.svelte
@@ -50,7 +50,7 @@
     const vision = await FilesetResolver.forVisionTasks('@mediapipe/tasks-vision/wasm');
     poseLandmarker = await PoseLandmarker.createFromOptions(vision, {
       baseOptions: {
-        /* Disabling GPU pose detection for now since it's exploding the WebGL context on iPad */
+        /* Disabling GPU pose detection for now on iPad since it's exploding the WebGL context */
         delegate: useGpu ? 'GPU' : 'CPU',
         modelAssetPath:
           // 'https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_heavy/float16/latest/pose_landmarker_heavy.task'
@@ -370,6 +370,7 @@
       <button on:click={onPlayClick}>Play</button>
     {/if}
     <input type="range" step="0.03" value="0" bind:this={rangeRef} on:input={onInput} />
+    <!-- TODO: remove this in design updates -->
     {fps}
   </div>
 </div>

--- a/src/routes/VideoScrubber.svelte
+++ b/src/routes/VideoScrubber.svelte
@@ -62,7 +62,11 @@
 
     if (isReference) {
       // Create glfx canvas for drawing perspective shift in reference video
-      glfxCanvas = fx.canvas();
+      try {
+        glfxCanvas = fx.canvas();
+      } catch (err) {
+        alert(err);
+      }
       glfxCanvas.className = frameCanvasRef.className;
       frameCanvasRef.replaceWith(glfxCanvas);
       frameCanvasRef = glfxCanvas;
@@ -372,7 +376,6 @@
 
   %canvas {
     position: absolute;
-    z-index: -1;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
@@ -397,6 +400,7 @@
     @extend %canvas;
 
     z-index: 2;
+    background-color: transparent;
   }
 
   .controls-container {

--- a/src/routes/VideoScrubber.svelte
+++ b/src/routes/VideoScrubber.svelte
@@ -78,6 +78,9 @@
     // Set canvas dimensions
     setCanvasDimensions(canvasWidth, canvasHeight);
 
+    // Mute video
+    videoRef.muted = true;
+
     // Draw the first frame of the video
     videoRef.currentTime = 0;
   });
@@ -314,6 +317,7 @@
     <video
       class="user-video"
       muted
+      playsinline
       crossorigin="anonymous"
       bind:this={videoRef}
       bind:duration={videoDuration}

--- a/src/routes/stores.ts
+++ b/src/routes/stores.ts
@@ -12,3 +12,5 @@ export const userCanvasDimensions = writable<[number, number]>();
 export const referencePerspective = writable<Perspective>();
 export const referencePose = writable<NormalizedLandmark[]>();
 export const referencePoseColor = writable<string>('blue');
+
+export const isMobile = writable(false);


### PR DESCRIPTION
## iOS Bugfixes

This PR resolves some issues we saw from initial iPad testing:

#### Only one video playing at a time on iPad
This had several layers to it.
* First, I think the videos had to be muted in order for multiple videos to play at once, so added the `muted` attributes in the `<video>` tags.
* Second, the way we were drawing the video in the glfx WebGL context was causing a lot of load on the GPU (creating new texture for each frame) as well as memory leaks (not deleting old frame textures when we're done drawing it). To fix this, we updated the frame texture logic to simply load the contents of the next video frame into the existing texture (glfx's `Texture` already included the function for doing this, which was nice).
* From these two fixes, we were able to get two videos playing simultaneously with pose detection on the iPad.

#### Video stuttering on iPad and iPhone
After implementing the above fix, I was still noticing that the video was stuttering significantly as we played it. It seemed that it was the underlying video stuttering as well, since the frame copying-to-canvas and pose detection were still happening at the exact same rate as the `requestAnimationFrame` was dictating. Empirically, I stumbled upon a fix where throttling the `requestAnimationFrame` calls actually seemed to smooth out the video, so that the effective frame rate actually improved significantly. My theory for the root cause was that doing eager executions of `requestAnimationFrame` simply caused too much load on the CPU/GPU, which caused the underlying video decoding/rendering itself to actually stall (perhaps the web logic somehow has priority over the video rendering process?). By throttling the web rendering logic, the video rendering also improved, and as a result the overall experience became much smoother. On my more powerful laptop, I've kept the eager `requestAnimationFrame` logic since it seemed to work fine without throttling.

#### Page size overflowing the viewport in mobile browsers
Due to some of the responsive behavior of viewport sizes in mobile browsers (eg. menu bar shrinking and stuff like that), we had to dynamically adjust the page height/width as the viewport changed. The value I was using (`100vh/vw`) only took the initial viewport size on page load. Changed this instead to `100dvh/dvw`, which takes the *dynamic* viewport width and height, which is perfectly what we want.

#### QOL changes
* Adding local development hosting script
  * This is a pretty simple change, just adding a script to start the Vite dev-mode server in hosting mode so that other devices on my local network can also access the site. This made testing on my iPad/iPhone much easier.
* Changing video `on:play` to `on:playing`, since the `playing` event seems to be more accurate for determining when a video is actually playing.